### PR TITLE
Add "arbitrary" feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "num-traits"
@@ -286,9 +286,9 @@ checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,20 @@ name = "base64_type"
 authors = [ "IronCore Labs <code@ironcorelabs.com>" ]
 version = "0.1.0"
 edition = "2018"
+resolver = "2"
 
 [dependencies]
 base64 = "0.13"
 base64-serde = "0.6"
 bytes = "1"
+proptest = { version = "1.0", optional = true }
+proptest-derive = { version = "0.3", optional = true }
 serde = "1"
 
 [dev-dependencies]
-proptest = "1.0"
+proptest = "1.0" 
 proptest-derive = "0.3"
 serde_json = "1"
+
+[features]
+arbitrary = [ "proptest", "proptest-derive" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use core::{
     ops::{Deref, DerefMut},
     str::FromStr,
 };
-#[cfg(test)]
+#[cfg(any(feature = "arbitrary", test))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -15,7 +15,7 @@ base64_serde_type!(Base64StandardSerde, STANDARD);
 /// Base64 newtype wrapper using `STANDARD` encoding. May be generally treated as if it
 /// were a primitive Vec, e.g. `&Base64` will provide `&[u8]`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(test, derive(Arbitrary))]
+#[cfg_attr(any(feature = "arbitrary", test), derive(Arbitrary))]
 pub struct Base64(pub Vec<u8>);
 impl Deref for Base64 {
     type Target = Vec<u8>;
@@ -105,7 +105,7 @@ impl TryFrom<Base64> for [u8; 32] {
 base64_serde_type!(UrlBase64Serde, URL_SAFE);
 /// Base64 newtype wrapper using `URL_SAFE` encoding. Used for Azure requests and responses.
 #[derive(Debug, PartialEq, Eq, Default)]
-#[cfg_attr(test, derive(Arbitrary))]
+#[cfg_attr(any(feature = "arbitrary", test), derive(Arbitrary))]
 pub struct UrlBase64(pub Vec<u8>);
 impl Serialize for UrlBase64 {
     fn serialize<S>(


### PR DESCRIPTION
Adds "arbitrary" feature flag that will include derivation of proptest Arbitrary for the exported types. To avoid adding proptest to your dependencies section, it's recommended to only turn on this flag in the dev-dependencies section.